### PR TITLE
Fixing capturing the session error

### DIFF
--- a/src/Helpers/functions.php
+++ b/src/Helpers/functions.php
@@ -28,7 +28,15 @@
                 $deviceDetector->setClientHints(ClientHints::factory($_SERVER));
                 $deviceDetector->parse();
 
-                $browser = $deviceDetector->getClient();
+                $client = $deviceDetector->getClient();
+                $browser = '';
+                if (is_array($client) && array_key_exists('name', $client)) {
+                    $browser.=$client['name'];
+                }
+                if (is_array($client) && array_key_exists('version', $client)) {
+                    $browser.=' '.$client['version'];
+                }
+
                 $os = $deviceDetector->getOs();
                 $device = $deviceDetector->getDeviceName();
 

--- a/src/Helpers/functions.php
+++ b/src/Helpers/functions.php
@@ -31,10 +31,10 @@
                 $client = $deviceDetector->getClient();
                 $browser = '';
                 if (is_array($client) && array_key_exists('name', $client)) {
-                    $browser.=$client['name'];
+                    $browser .= $client['name'];
                 }
                 if (is_array($client) && array_key_exists('version', $client)) {
-                    $browser.=' '.$client['version'];
+                    $browser .= ' '.$client['version'];
                 }
 
                 $os = $deviceDetector->getOs();

--- a/tests/Unit/SessionModelTest.php
+++ b/tests/Unit/SessionModelTest.php
@@ -24,6 +24,7 @@ class SessionModelTest extends TestCase
      */
     public function create(): void
     {
+        request()->headers->set('User-Agent','Mozilla/5.0 (X11; Linux x86_64; rv:130.0) Gecko/20100101 Firefox/130.0');
         $user = UserFactory::createNormalUser();
         $model = capture_session($user);
 

--- a/tests/Unit/SessionModelTest.php
+++ b/tests/Unit/SessionModelTest.php
@@ -24,7 +24,7 @@ class SessionModelTest extends TestCase
      */
     public function create(): void
     {
-        request()->headers->set('User-Agent','Mozilla/5.0 (X11; Linux x86_64; rv:130.0) Gecko/20100101 Firefox/130.0');
+        request()->headers->set('User-Agent', 'Mozilla/5.0 (X11; Linux x86_64; rv:130.0) Gecko/20100101 Firefox/130.0');
         $user = UserFactory::createNormalUser();
         $model = capture_session($user);
 


### PR DESCRIPTION
While capturing the session, getting the details of the user's browser causes an `array to string conversion` error.
Now, the browser info will be created using the parsed array of the user's `User-Agent` value.